### PR TITLE
Fixes for Pretty Print and Duplicate Values issues.

### DIFF
--- a/Sources/LightJson/Serialization/JsonReader.cs
+++ b/Sources/LightJson/Serialization/JsonReader.cs
@@ -309,7 +309,7 @@ namespace LightJson.Serialization
 
 					var key = ReadJsonKey();
 
-					if (jsonObject.Contains(key))
+					if (jsonObject.ContainsKey(key))
 					{
 						throw new JsonParseException(
 							ErrorType.DuplicateObjectKeys,

--- a/Sources/LightJson/Serialization/JsonWriter.cs
+++ b/Sources/LightJson/Serialization/JsonWriter.cs
@@ -119,7 +119,7 @@ namespace LightJson.Serialization
 
 		private void WriteEncodedString(string text)
 		{
-			this.writer.Write("\"");
+			Write("\"");
 
 			for (int i = 0; i < text.Length; i += 1)
 			{


### PR DESCRIPTION
First, I appreciate you making the library available.  It definitely saved me some time.

This addresses two bugs I encountered.

1. Indentation would not be inserted on any line with key/value pairs.  This is because the call to write the keys circumvented the check performed by `Write` to provide the indentation.
2. The deserialization code was checking new keys against prior values, rather than prior keys.

Thanks! 