### PR TITLE
Fixing bug in initialization of Position member in JsonParseException constructor

### DIFF
--- a/Sources/LightJson/Serialization/JsonParseException.cs
+++ b/Sources/LightJson/Serialization/JsonParseException.cs
@@ -44,7 +44,7 @@ namespace LightJson.Serialization
 			: base(message)
 		{
 			this.Type = type;
-			this.Position = Position;
+			this.Position = position;
 		}
 
 		private static string GetDefaultMessage(ErrorType type)


### PR DESCRIPTION
Another small one.

The constructor of JsonParseException was setting its Position member to itself rather than the argument.