### PR TITLE
Include source files in nuget package

### DIFF
--- a/Sources/LightJson/LightJson.csproj
+++ b/Sources/LightJson/LightJson.csproj
@@ -43,6 +43,19 @@
     <None Remove="LightJson.xml" />
     <None Include="../../README.md;../../LICENSE.txt" Pack="true" PackagePath="/"/>
 
+    <!-- Pack sources in the nuget package -->
+    <Content Include="Package\**">
+	    <Pack>true</Pack>
+	    <PackagePath>build\</PackagePath>
+	    <PackageCopyToOutput>true</PackageCopyToOutput>
+    </Content>
+
+    <Content Include="**\*.cs" Exclude="**\obj\**;**\bin\**">
+	    <Pack>true</Pack>
+	    <PackagePath>src\LightJson\</PackagePath>
+	    <PackageCopyToOutput>true</PackageCopyToOutput>
+    </Content>
+
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
   </ItemGroup>
 

--- a/Sources/LightJson/Package/MarcosLopezC.LightJson.targets
+++ b/Sources/LightJson/Package/MarcosLopezC.LightJson.targets
@@ -1,0 +1,5 @@
+<Project>
+	<ItemGroup Condition="'$(PackageLightJsonIncludeSource)' == 'true'">
+		<Compile Include="$(MSBuildThisFileDirectory)../src/**/*.cs" Visible="false"/>
+	</ItemGroup>
+</Project>


### PR DESCRIPTION
This addresses #49 by including the source code in the package.

When referencing the package, it can now be done with:
```xml
<PropertyGroup>
  <PackageLightJsonIncludeSource>true</PackageLightJsonIncludeSource>
</PropertyGroup>

<ItemGroup>
  <PackageReference Include="MarcosLopezC.LightJson" Version="0.5.2" IncludeAssets="Build" />
</ItemGroup>
```

This will mean that instead of having a direct reference to the compiled dll, the source code will instead be used.
This solves all kinds of issues when using it in a source generator/analyzer.