### PR TITLE
Include source files in nuget package (Internal types)

### DIFF
--- a/Sources/LightJson/JsonArray.cs
+++ b/Sources/LightJson/JsonArray.cs
@@ -10,7 +10,12 @@ namespace LightJson
 	/// </summary>
 	[DebuggerDisplay("Count = {Count}")]
 	[DebuggerTypeProxy(typeof(JsonArrayDebugView))]
-	public sealed class JsonArray : IEnumerable<JsonValue>
+#if LIGHTJSON_INTERNAL
+    internal
+#else
+    public
+#endif
+    sealed class JsonArray : IEnumerable<JsonValue>
 	{
 		private IList<JsonValue> items;
 

--- a/Sources/LightJson/JsonObject.cs
+++ b/Sources/LightJson/JsonObject.cs
@@ -10,7 +10,12 @@ namespace LightJson
 	/// </summary>
 	[DebuggerDisplay("Count = {Count}")]
 	[DebuggerTypeProxy(typeof(JsonObjectDebugView))]
-	public sealed class JsonObject : IEnumerable<KeyValuePair<string, JsonValue>>, IEnumerable<JsonValue>
+#if LIGHTJSON_INTERNAL
+    internal
+#else
+    public
+#endif
+    sealed class JsonObject : IEnumerable<KeyValuePair<string, JsonValue>>, IEnumerable<JsonValue>
 	{
 		private IDictionary<string, JsonValue> properties;
 

--- a/Sources/LightJson/JsonValue.cs
+++ b/Sources/LightJson/JsonValue.cs
@@ -10,7 +10,12 @@ namespace LightJson
 	/// </summary>
 	[DebuggerDisplay("{ToString(),nq}", Type = "JsonValue({Type})")]
 	[DebuggerTypeProxy(typeof(JsonValueDebugView))]
-	public struct JsonValue
+#if LIGHTJSON_INTERNAL
+    internal
+#else
+    public
+#endif
+    struct JsonValue
 	{
 		private readonly JsonValueType type;
 		private readonly object reference;

--- a/Sources/LightJson/JsonValueType.cs
+++ b/Sources/LightJson/JsonValueType.cs
@@ -5,7 +5,12 @@ namespace LightJson
 	/// <summary>
 	/// Enumerates the types of Json values.
 	/// </summary>
-	public enum JsonValueType : byte
+#if LIGHTJSON_INTERNAL
+    internal
+#else
+    public
+#endif
+    enum JsonValueType : byte
 	{
 		/// <summary>
 		/// A null value.

--- a/Sources/LightJson/LightJson.csproj
+++ b/Sources/LightJson/LightJson.csproj
@@ -43,6 +43,19 @@
     <None Remove="LightJson.xml" />
     <None Include="../../README.md;../../LICENSE.txt" Pack="true" PackagePath="/"/>
 
+    <!-- Pack sources in the nuget package -->
+    <Content Include="Package\**">
+	    <Pack>true</Pack>
+	    <PackagePath>build\</PackagePath>
+	    <PackageCopyToOutput>true</PackageCopyToOutput>
+    </Content>
+
+    <Content Include="**\*.cs" Exclude="**\obj\**;**\bin\**">
+	    <Pack>true</Pack>
+	    <PackagePath>src\LightJson\</PackagePath>
+	    <PackageCopyToOutput>true</PackageCopyToOutput>
+    </Content>
+
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
   </ItemGroup>
 

--- a/Sources/LightJson/Package/MarcosLopezC.LightJson.targets
+++ b/Sources/LightJson/Package/MarcosLopezC.LightJson.targets
@@ -1,4 +1,7 @@
 <Project>
+	<PropertyGroup Condition="'$(PackageLightJsonIncludeSource)' == 'true'">
+		<DefineConstants>$(DefineConstants);LIGHTJSON_INTERNAL</DefineConstants>
+	</PropertyGroup>
 	<ItemGroup Condition="'$(PackageLightJsonIncludeSource)' == 'true'">
 		<Compile Include="$(MSBuildThisFileDirectory)../src/**/*.cs" Visible="false"/>
 	</ItemGroup>

--- a/Sources/LightJson/Package/MarcosLopezC.LightJson.targets
+++ b/Sources/LightJson/Package/MarcosLopezC.LightJson.targets
@@ -1,0 +1,5 @@
+<Project>
+	<ItemGroup Condition="'$(PackageLightJsonIncludeSource)' == 'true'">
+		<Compile Include="$(MSBuildThisFileDirectory)../src/**/*.cs" Visible="false"/>
+	</ItemGroup>
+</Project>

--- a/Sources/LightJson/Serialization/JsonParseException.cs
+++ b/Sources/LightJson/Serialization/JsonParseException.cs
@@ -8,7 +8,12 @@ namespace LightJson.Serialization
 	/// <remarks>
 	/// This exception is only intended to be thrown by LightJson.
 	/// </remarks>
-	public sealed class JsonParseException : Exception
+#if LIGHTJSON_INTERNAL
+    internal
+#else
+    public
+#endif
+    sealed class JsonParseException : Exception
 	{
 		/// <summary>
 		/// Gets the text position where the error occurred.

--- a/Sources/LightJson/Serialization/JsonReader.cs
+++ b/Sources/LightJson/Serialization/JsonReader.cs
@@ -10,7 +10,12 @@ namespace LightJson.Serialization
 	/// <summary>
 	/// Represents a reader that can read JsonValues.
 	/// </summary>
-	public sealed class JsonReader
+#if LIGHTJSON_INTERNAL
+    internal
+#else
+    public
+#endif
+    sealed class JsonReader
 	{
 		private TextScanner scanner;
 

--- a/Sources/LightJson/Serialization/JsonSerializationException.cs
+++ b/Sources/LightJson/Serialization/JsonSerializationException.cs
@@ -8,7 +8,12 @@ namespace LightJson.Serialization
 	/// <remarks>
 	/// This exception is only intended to be thrown by LightJson.
 	/// </remarks>
-	public sealed class JsonSerializationException : Exception
+#if LIGHTJSON_INTERNAL
+    internal
+#else
+    public
+#endif
+    sealed class JsonSerializationException : Exception
 	{
 		/// <summary>
 		/// Gets the type of error that caused the exception to be thrown.

--- a/Sources/LightJson/Serialization/JsonWriter.cs
+++ b/Sources/LightJson/Serialization/JsonWriter.cs
@@ -11,7 +11,12 @@ namespace LightJson.Serialization
 	/// <summary>
 	/// Represents a TextWriter adapter that can write string representations of JsonValues.
 	/// </summary>
-	public sealed class JsonWriter
+#if LIGHTJSON_INTERNAL
+    internal
+#else
+    public
+#endif
+    sealed class JsonWriter
 	{
 		private int indent;
 		private bool isNewLine;

--- a/Sources/LightJson/Serialization/TextPosition.cs
+++ b/Sources/LightJson/Serialization/TextPosition.cs
@@ -5,7 +5,12 @@ namespace LightJson.Serialization
 	/// <summary>
 	/// Represents a position within a plain text resource.
 	/// </summary>
-	public struct TextPosition
+#if LIGHTJSON_INTERNAL
+    internal
+#else
+    public
+#endif
+    struct TextPosition
 	{
 		/// <summary>
 		/// The column position, 0-based.

--- a/Sources/LightJson/Serialization/TextScanner.cs
+++ b/Sources/LightJson/Serialization/TextScanner.cs
@@ -9,7 +9,12 @@ namespace LightJson.Serialization
 	/// <summary>
 	/// Represents a text scanner that reads one character at a time.
 	/// </summary>
-	public sealed class TextScanner
+#if LIGHTJSON_INTERNAL
+    internal
+#else
+    public
+#endif
+    sealed class TextScanner
 	{
 		private TextReader reader;
 		private TextPosition position;


### PR DESCRIPTION
This builds on top of #50 to also make the included types, when using source embedded internal.
This is a nice to have, to ensure consuming packages aren't exposing the types, but does pollute the code a little with the extra compiler directives.

As such, and because this isn't entirely necessary for source generators, I wasn't sure we wanted to include it.

For context, when a consuming project references the source generator, it should really only include the analyzers, which means that the actual dll won't have any reference to the source generator/analyzer itself.
This means that even if the included types are public, they won't be exposed, so not a problem
