### PR TITLE
Copy source files with .g.cs file extension

### DIFF
--- a/Sources/LightJson/LightJson.csproj
+++ b/Sources/LightJson/LightJson.csproj
@@ -52,7 +52,7 @@
 
     <Content Include="**\*.cs" Exclude="**\obj\**;**\bin\**">
       <Pack>true</Pack>
-      <PackagePath>src\LightJson\</PackagePath>
+      <PackagePath>src\LightJson\%(RecursiveDir)%(Filename).g%(Extension)</PackagePath>
       <PackageCopyToOutput>true</PackageCopyToOutput>
     </Content>
 


### PR DESCRIPTION
While using the new source functionality, I noticed I was getting a few compiler warnings in the included source files.
This was mostly because I had a few strict rules that were different than the code style used in the project.

This will copy the files with a `.g.cs` file extension instead of `.cs`, causing them to be seen as auto-generated, which ensures consuming projects don't receive warnings regarding them.